### PR TITLE
Allow setting `display` via system property

### DIFF
--- a/core/src/main/java/com/automation/remarks/video/recorder/ffmpeg/LinuxFFmpegRecorder.java
+++ b/core/src/main/java/com/automation/remarks/video/recorder/ffmpeg/LinuxFFmpegRecorder.java
@@ -6,7 +6,7 @@ package com.automation.remarks.video.recorder.ffmpeg;
 public class LinuxFFmpegRecorder extends FFMpegRecorder {
     @Override
     public void start() {
-        String display = System.setProperty("recorder.display", ":0.0");
+        String display = System.getProperty("recorder.display", ":0.0");
         String recorder = "x11grab";
         getFfmpegWrapper().startFFmpeg(display, recorder);
     }

--- a/core/src/main/java/com/automation/remarks/video/recorder/ffmpeg/LinuxFFmpegRecorder.java
+++ b/core/src/main/java/com/automation/remarks/video/recorder/ffmpeg/LinuxFFmpegRecorder.java
@@ -6,7 +6,7 @@ package com.automation.remarks.video.recorder.ffmpeg;
 public class LinuxFFmpegRecorder extends FFMpegRecorder {
     @Override
     public void start() {
-        String display = ":0.0";
+        String display = System.setProperty("recorder.display", ":0.0");
         String recorder = "x11grab";
         getFfmpegWrapper().startFFmpeg(display, recorder);
     }


### PR DESCRIPTION
`$DISPLAY` property varies from `:0.0` on multi-display workstations or if using Xvfb with default display `:99.0`. Could you please add possibility to set display via system property?