### PR TITLE
Allow setting ffmpeg properties via system properties

### DIFF
--- a/core/src/main/java/com/automation/remarks/video/SystemUtils.java
+++ b/core/src/main/java/com/automation/remarks/video/SystemUtils.java
@@ -1,5 +1,6 @@
 package com.automation.remarks.video;
 
+import com.automation.remarks.video.enums.OsType;
 import com.automation.remarks.video.exception.RecordingException;
 import com.automation.remarks.video.recorder.ffmpeg.FFMpegRecorder;
 import org.apache.log4j.Logger;
@@ -10,6 +11,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
+
+import static org.apache.commons.lang3.SystemUtils.IS_OS_MAC;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 
 /**
  * Created by sepi on 31.08.16.
@@ -53,5 +57,14 @@ public class SystemUtils {
 
     public static Dimension getSystemScreenDimension() {
         return Toolkit.getDefaultToolkit().getScreenSize();
+    }
+
+    public static String getOsType() {
+        if (IS_OS_WINDOWS) {
+            return OsType.windows.name();
+        } else if (IS_OS_MAC) {
+            return OsType.mac.name();
+        }
+        return OsType.linux.name();
     }
 }

--- a/core/src/main/java/com/automation/remarks/video/enums/OsType.java
+++ b/core/src/main/java/com/automation/remarks/video/enums/OsType.java
@@ -1,0 +1,7 @@
+package com.automation.remarks.video.enums;
+
+public enum OsType {
+    windows,
+    mac,
+    linux
+}

--- a/core/src/main/java/com/automation/remarks/video/recorder/VideoConfiguration.java
+++ b/core/src/main/java/com/automation/remarks/video/recorder/VideoConfiguration.java
@@ -5,6 +5,9 @@ import com.automation.remarks.video.enums.RecorderType;
 import com.automation.remarks.video.enums.RecordingMode;
 import com.automation.remarks.video.enums.VideoSaveMode;
 import org.aeonbits.owner.Config;
+import org.aeonbits.owner.Config.LoadPolicy;
+import org.aeonbits.owner.Config.LoadType;
+import org.aeonbits.owner.Config.Sources;
 
 import java.awt.*;
 import java.io.File;
@@ -12,7 +15,9 @@ import java.io.File;
 /**
  * Created by sergey on 4/13/16.
  */
-@Config.Sources("classpath:video.properties")
+@LoadPolicy(LoadType.MERGE)
+@Sources({ "classpath:video.properties",
+           "classpath:ffmpeg-${os.type}.properties" })
 public interface VideoConfiguration extends Config {
 
   @Key("video.folder")
@@ -48,4 +53,10 @@ public interface VideoConfiguration extends Config {
   default Dimension screenSize() {
     return SystemUtils.getSystemScreenDimension();
   }
+
+  @Key("ffmpeg.format")
+  String ffmpegFormat();
+
+  @Key("ffmpeg.display")
+  String ffmpegDisplay();
 }

--- a/core/src/main/java/com/automation/remarks/video/recorder/VideoRecorder.java
+++ b/core/src/main/java/com/automation/remarks/video/recorder/VideoRecorder.java
@@ -4,11 +4,14 @@ import org.aeonbits.owner.ConfigFactory;
 
 import java.io.File;
 
+import static com.automation.remarks.video.SystemUtils.getOsType;
+
 /**
  * Created by sepi on 19.07.16.
  */
 public abstract class VideoRecorder implements IVideoRecorder {
   public static VideoConfiguration conf() {
+    ConfigFactory.setProperty("os.type", getOsType());
     return ConfigFactory.create(VideoConfiguration.class, System.getProperties());
   }
 

--- a/core/src/main/java/com/automation/remarks/video/recorder/ffmpeg/FFmpegWrapper.java
+++ b/core/src/main/java/com/automation/remarks/video/recorder/ffmpeg/FFmpegWrapper.java
@@ -28,7 +28,7 @@ public class FFmpegWrapper {
     private CompletableFuture<String> future;
     private File temporaryFile;
 
-    public void startFFmpeg(String display, String recorder, String... args) {
+    public void startFFmpeg(String... args) {
         File videoFolder = new File(conf().folder());
         if (!videoFolder.exists()) {
             videoFolder.mkdirs();
@@ -36,10 +36,11 @@ public class FFmpegWrapper {
 
         temporaryFile = getTemporaryFile();
         final String[] commandsSequence = new String[]{
-                FFmpegWrapper.RECORDING_TOOL, "-y",
+                FFmpegWrapper.RECORDING_TOOL,
+                "-y",
                 "-video_size", getScreenSize(),
-                "-f", recorder,
-                "-i", display,
+                "-f", conf().ffmpegFormat(),
+                "-i", conf().ffmpegDisplay(),
                 "-an",
                 "-framerate", String.valueOf(conf().frameRate()),
                 temporaryFile.getAbsolutePath()

--- a/core/src/main/java/com/automation/remarks/video/recorder/ffmpeg/LinuxFFmpegRecorder.java
+++ b/core/src/main/java/com/automation/remarks/video/recorder/ffmpeg/LinuxFFmpegRecorder.java
@@ -6,8 +6,6 @@ package com.automation.remarks.video.recorder.ffmpeg;
 public class LinuxFFmpegRecorder extends FFMpegRecorder {
     @Override
     public void start() {
-        String display = ":0.0";
-        String recorder = "x11grab";
-        getFfmpegWrapper().startFFmpeg(display, recorder);
+        getFfmpegWrapper().startFFmpeg();
     }
 }

--- a/core/src/main/java/com/automation/remarks/video/recorder/ffmpeg/MacFFmpegRecorder.java
+++ b/core/src/main/java/com/automation/remarks/video/recorder/ffmpeg/MacFFmpegRecorder.java
@@ -6,8 +6,6 @@ package com.automation.remarks.video.recorder.ffmpeg;
 public class MacFFmpegRecorder extends FFMpegRecorder {
     @Override
     public void start() {
-        String display = "1:";
-        String recorder = "avfoundation";
-        getFfmpegWrapper().startFFmpeg(display, recorder, "-vsync", "2");
+        getFfmpegWrapper().startFFmpeg("-vsync", "2");
     }
 }

--- a/core/src/main/java/com/automation/remarks/video/recorder/ffmpeg/WindowsFFmpegRecorder.java
+++ b/core/src/main/java/com/automation/remarks/video/recorder/ffmpeg/WindowsFFmpegRecorder.java
@@ -7,8 +7,6 @@ public class WindowsFFmpegRecorder extends FFMpegRecorder {
 
     @Override
     public void start() {
-        String display = "desktop";
-        String recorder = "gdigrab";
-        getFfmpegWrapper().startFFmpeg(display, recorder);
+        getFfmpegWrapper().startFFmpeg();
     }
 }

--- a/core/src/main/resources/ffmpeg-linux.properties
+++ b/core/src/main/resources/ffmpeg-linux.properties
@@ -1,0 +1,2 @@
+ffmpeg.format=x11grab
+ffmpeg.display=:1.0

--- a/core/src/main/resources/ffmpeg-mac.properties
+++ b/core/src/main/resources/ffmpeg-mac.properties
@@ -1,0 +1,2 @@
+ffmpeg.format=avfoundation
+ffmpeg.display=1:

--- a/core/src/main/resources/ffmpeg-windows.properties
+++ b/core/src/main/resources/ffmpeg-windows.properties
@@ -1,0 +1,2 @@
+ffmpeg.format=gdigrab
+ffmpeg.display=desktop


### PR DESCRIPTION
$DISPLAY property varies from :0.0 on multi-display workstations or if using Xvfb with default display :99.0. Exposing `display` property to configuration adds flexibility for end user - now it's possible to set offset and change display, i.e. `:1.0+10,20`