### PR TITLE
Add possibility to pass ffmpeg pixel format (for Apple 'QuickTime' player compatibility)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -214,7 +214,7 @@ To be sure that everything works properly, open CMD and perform first command:
 
 *ffmpeg*
 
-The output shoul lopk like this:
+The output should look like this:
 ----
 C:\Users\sepi>ffmpeg
 ffmpeg version N-81234-ge1be80a Copyright (c) 2000-2016 the FFmpeg developers

--- a/README.adoc
+++ b/README.adoc
@@ -156,6 +156,7 @@ video.save.mode=ALL               // default FAILED_ONLY
 video.frame.rate=1                // default 24
 ffmpeg.format=x11grab             // default value depends on OS platform
 ffmpeg.display=:0.0               // default value depends on OS platform
+ffmpeg.pixelFormat=yuv444p        // default yuv420p (for Apple QuickTime player compatibility)
 ----
 
 or with maven
@@ -169,6 +170,7 @@ or with maven
           -Dvideo.frame.rate=1         // default 24
           -Dvideo.screen.size=1024x768 // custom screen size
           -Dffmpeg.display=:1.0+10,20  // custom display configuration for ffmpeg
+          -Dffmpeg.pixelFormat=yuv444p // default yuv420p
 ----
 
 === FFMPEG recorder configuration

--- a/core/src/main/java/com/automation/remarks/video/recorder/VideoConfiguration.java
+++ b/core/src/main/java/com/automation/remarks/video/recorder/VideoConfiguration.java
@@ -60,4 +60,8 @@ public interface VideoConfiguration extends Config {
 
   @Key("ffmpeg.display")
   String ffmpegDisplay();
+
+  @DefaultValue("yuv420p")
+  @Key("ffmpeg.pixelFormat")
+  String ffmpegPixelFormat();
 }

--- a/core/src/main/java/com/automation/remarks/video/recorder/ffmpeg/FFmpegWrapper.java
+++ b/core/src/main/java/com/automation/remarks/video/recorder/ffmpeg/FFmpegWrapper.java
@@ -43,6 +43,7 @@ public class FFmpegWrapper {
                 "-i", conf().ffmpegDisplay(),
                 "-an",
                 "-framerate", String.valueOf(conf().frameRate()),
+                "-pix_fmt", conf().ffmpegPixelFormat(),
                 temporaryFile.getAbsolutePath()
         };
 

--- a/core/src/test/groovy/test/VideoRecorderTest.groovy
+++ b/core/src/test/groovy/test/VideoRecorderTest.groovy
@@ -77,4 +77,18 @@ class VideoRecorderTest extends SpockBaseTest {
         // Alternative syntax: def ex = thrown(InvalidDeviceException)
         ex.message == "Video recording wasn't started"
     }
+
+    def "should record video with custom pixel format for #type"() {
+        given:
+        System.setProperty("recorder.type", type.toString())
+        System.setProperty("ffmpeg.pixelFormat", "yuv444p")
+
+        when:
+        File video = recordVideo()
+        then:
+        video.exists()
+
+        where:
+        type << [RecorderType.FFMPEG, RecorderType.MONTE]
+    }
 }


### PR DESCRIPTION
I've found it necessary to pass -pix_fmt=yuv420p in order to have ffmpeg record video playable by Apple's QuickTime player. But it seems Video Recored doesn't provide the ability to set this option to ffmpeg command argument. This pull request adds that.

Several details. From the [official documentation](https://ffmpeg.org/ffmpeg.html#Advanced-Video-options): 

> If the selected pixel format can not be selected, ffmpeg will print a warning and select the best pixel format supported by the encoder