### PR TITLE
Feature universal testng listener

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -121,9 +121,9 @@ import com.automation.remarks.video.testng.VideoListener;
 import org.testng.annotations.Listeners;  
 import org.testng.annotations.Test;
 
-import static junit.framework.Assert.assertTrue;
+import static org.testng.Assert.assertTrue;
 
-@Listeners(VideoListener.class)
+@Listeners(UniversalVideoListener.class)
 public class TestNgVideoTest {
 
     @Test

--- a/README.adoc
+++ b/README.adoc
@@ -340,7 +340,7 @@ log4j.logger.com.automation.remarks.video.recorder=DEBUG, FA
 log4j.additivity.com.automation.remarks.video.recorder=false
 ----
 
-## License
+== License
 
 See https://github.com/SergeyPirogov/video-recorder-java/blob/master/LICENSE.txt/[LICENSE].
 

--- a/README.adoc
+++ b/README.adoc
@@ -291,7 +291,7 @@ import static com.automation.remarks.testng.test.TestNGRemoteListenerTest.startG
 import static org.testng.Assert.fail;
 
 
-@Listeners(RemoteVideoListener.class)
+@Listeners(UniversalVideoListener.class)
 public class IntegrationTest {
 
     RemoteWebDriver driver;
@@ -301,8 +301,8 @@ public class IntegrationTest {
         URL hubUrl = new URL("http://localhost:4444/wd/hub");
         driver = new RemoteWebDriver(hubUrl, DesiredCapabilities.firefox());
         String nodeIp = GridInfoExtractor.getNodeIp(hubUrl, driver.getSessionId().toString());
-        VideoRecorder.conf()
-                .withRemoteUrl(nodeIp);
+        System.setProperty("video.remote", "true");
+        System.setProperty("remote.video.hub", nodeIp);
     }
 
     @Test

--- a/core/src/main/java/com/automation/remarks/video/RecordingUtils.java
+++ b/core/src/main/java/com/automation/remarks/video/RecordingUtils.java
@@ -15,55 +15,57 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
  */
 public class RecordingUtils {
 
-    private static final Logger logger = Logger.getLogger(RecordingUtils.class);
+  private static final Logger logger = Logger.getLogger(RecordingUtils.class);
 
-    private RecordingUtils() {
-    }
+  private RecordingUtils() {
+  }
 
-    public static String doVideoProcessing(boolean successfulTest, File video) {
-        String filePath = formatVideoFilePath(video);
-        if (!successfulTest || VideoRecorder.conf().saveMode().equals(VideoSaveMode.ALL)) {
-            logger.info("Video recording: " + filePath);
-            return filePath;
-        } else if (video != null) {
-            video.delete();
-            logger.info("No video on success test");
-        }
-        return "";
+  public static String doVideoProcessing(boolean successfulTest, File video) {
+    String filePath = formatVideoFilePath(video);
+    if (!successfulTest || VideoRecorder.conf().saveMode().equals(VideoSaveMode.ALL)) {
+      logger.info("Video recording: " + filePath);
+      return filePath;
+    } else if (video != null) {
+      video.delete();
+      logger.info("No video on success test");
     }
+    return "";
+  }
 
-    public static boolean videoEnabled(Video video) {
-        return VideoRecorder.conf().videoEnabled()
-                && (VideoRecorder.conf().mode().equals(ALL)
-                || video != null);
-    }
+  public static boolean videoEnabled(Video video) {
+    return VideoRecorder.conf().videoEnabled()
+        && (VideoRecorder.conf().mode().equals(ALL)
+        || video != null);
+  }
 
-    public static String getVideoFileName(Video annotation, String methodName) {
-        if (annotation == null) {
-            return methodName;
-        }
-        String name = annotation.name();
-        return name.length() > 1 ? name : methodName;
+  public static String getVideoFileName(Video annotation, String methodName) {
+    if (annotation == null && VideoRecorder.conf().fileName() != null) {
+      return VideoRecorder.conf().fileName();
+    } else if (annotation == null) {
+      return methodName;
     }
+    String name = annotation.name();
+    return name.length() > 1 ? name : methodName;
+  }
 
-    private static String formatVideoFilePath(File video) {
-        if (video == null) {
-            return "";
-        }
-        String jenkinsReportsUrl = getJenkinsReportsUrl();
-        if (!isBlank(jenkinsReportsUrl)) {
-            return jenkinsReportsUrl + video.getName();
-        }
-        return video.getAbsolutePath();
+  private static String formatVideoFilePath(File video) {
+    if (video == null) {
+      return "";
     }
+    String jenkinsReportsUrl = getJenkinsReportsUrl();
+    if (!isBlank(jenkinsReportsUrl)) {
+      return jenkinsReportsUrl + video.getName();
+    }
+    return video.getAbsolutePath();
+  }
 
-    private static String getJenkinsReportsUrl() {
-        String jenkins_url = System.getProperty("jenkins_url");
-        if (!isBlank(jenkins_url)) {
-            return jenkins_url;
-        } else {
-            logger.info("No jenkins_url variable found.");
-            return null;
-        }
+  private static String getJenkinsReportsUrl() {
+    String jenkins_url = System.getProperty("jenkins_url");
+    if (!isBlank(jenkins_url)) {
+      return jenkins_url;
+    } else {
+      logger.info("No jenkins_url variable found.");
+      return null;
     }
+  }
 }

--- a/core/src/main/java/com/automation/remarks/video/RecordingUtils.java
+++ b/core/src/main/java/com/automation/remarks/video/RecordingUtils.java
@@ -1,13 +1,13 @@
 package com.automation.remarks.video;
 
 import com.automation.remarks.video.annotations.Video;
+import com.automation.remarks.video.enums.RecordingMode;
 import com.automation.remarks.video.enums.VideoSaveMode;
 import com.automation.remarks.video.recorder.VideoRecorder;
 import org.apache.log4j.Logger;
 
 import java.io.File;
 
-import static com.automation.remarks.video.enums.RecordingMode.ALL;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
@@ -22,30 +22,44 @@ public class RecordingUtils {
 
   public static String doVideoProcessing(boolean successfulTest, File video) {
     String filePath = formatVideoFilePath(video);
-    if (!successfulTest || VideoRecorder.conf().saveMode().equals(VideoSaveMode.ALL)) {
+    if (!successfulTest || isSaveAllModeEnable()) {
       logger.info("Video recording: " + filePath);
       return filePath;
-    } else if (video != null) {
-      video.delete();
+    } else if (video != null && video.isFile()) {
+      if (!video.delete()) {
+        logger.info("Video didn't deleted");
+        return "Video didn't deleted";
+      }
       logger.info("No video on success test");
     }
     return "";
   }
 
+  private static boolean isSaveAllModeEnable() {
+    return VideoRecorder.conf().saveMode().equals(VideoSaveMode.ALL);
+  }
+
   public static boolean videoEnabled(Video video) {
     return VideoRecorder.conf().videoEnabled()
-        && (VideoRecorder.conf().mode().equals(ALL)
-        || video != null);
+        && (isRecordingAllModeEnable() || video != null);
+  }
+
+  private static boolean isRecordingAllModeEnable() {
+    return VideoRecorder.conf().mode().equals(RecordingMode.ALL);
   }
 
   public static String getVideoFileName(Video annotation, String methodName) {
-    if ((annotation == null || annotation.name().isEmpty()) && VideoRecorder.conf().fileName() != null) {
+    if (useNameFromVideoAnnotation(annotation) && VideoRecorder.conf().fileName() != null) {
       return VideoRecorder.conf().fileName();
     } else if (annotation == null) {
       return methodName;
     }
     String name = annotation.name();
     return name.length() > 1 ? name : methodName;
+  }
+
+  private static boolean useNameFromVideoAnnotation(Video annotation) {
+    return annotation == null || annotation.name().isEmpty();
   }
 
   private static String formatVideoFilePath(File video) {
@@ -60,12 +74,12 @@ public class RecordingUtils {
   }
 
   private static String getJenkinsReportsUrl() {
-    String jenkins_url = System.getProperty("jenkins_url");
-    if (!isBlank(jenkins_url)) {
-      return jenkins_url;
+    String jenkinsUrl = System.getProperty("jenkinsUrl");
+    if (!isBlank(jenkinsUrl)) {
+      return jenkinsUrl;
     } else {
-      logger.info("No jenkins_url variable found.");
-      return null;
+      logger.info("No jenkinsUrl variable found.");
+      return "";
     }
   }
 }

--- a/core/src/main/java/com/automation/remarks/video/recorder/IVideoRecorder.java
+++ b/core/src/main/java/com/automation/remarks/video/recorder/IVideoRecorder.java
@@ -1,7 +1,6 @@
 package com.automation.remarks.video.recorder;
 
 import java.io.File;
-import java.util.LinkedList;
 
 /**
  * Created by sergey on 4/30/16.

--- a/core/src/main/java/com/automation/remarks/video/recorder/VideoConfiguration.java
+++ b/core/src/main/java/com/automation/remarks/video/recorder/VideoConfiguration.java
@@ -38,6 +38,13 @@ public interface VideoConfiguration extends Config {
   @Key("remote.video.hub")
   String remoteUrl();
 
+  @DefaultValue("false")
+  @Key("video.remote")
+  Boolean isRemote();
+
+  @Key("video.name")
+  String fileName();
+
   @Key("recorder.type")
   @DefaultValue("MONTE")
   RecorderType recorderType();

--- a/core/src/test/groovy/test/VideoConfigurationTest.groovy
+++ b/core/src/test/groovy/test/VideoConfigurationTest.groovy
@@ -27,5 +27,7 @@ class VideoConfigurationTest extends SpockBaseTest {
         conf.saveMode() == VideoSaveMode.FAILED_ONLY
         conf.videoEnabled()
         conf.screenSize() == SystemUtils.systemScreenDimension
+        !conf.isRemote()
+        conf.fileName() == null
     }
 }

--- a/remote/src/main/java/com/automation/remarks/remote/node/Video.java
+++ b/remote/src/main/java/com/automation/remarks/remote/node/Video.java
@@ -26,7 +26,7 @@ public class Video extends HttpServlet {
   }
 
   @Override
-  protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+  protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     process(req, resp);
   }
 
@@ -52,7 +52,7 @@ public class Video extends HttpServlet {
           String fileName = getFileName(req);
           File video = videoRecorder.stopAndSave(fileName);
           String filePath = doVideoProcessing(isSuccess(req), video);
-          updateResponse(resp, HttpStatus.SC_OK, "recording stopped " + filePath);
+          updateResponse(resp, HttpStatus.SC_OK, filePath);
           break;
       }
     } catch (Exception ex) {

--- a/remote/src/main/java/com/automation/remarks/remote/node/Video.java
+++ b/remote/src/main/java/com/automation/remarks/remote/node/Video.java
@@ -3,7 +3,6 @@ package com.automation.remarks.remote.node;
 import com.automation.remarks.video.recorder.monte.MonteRecorder;
 import org.apache.http.HttpStatus;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -21,7 +20,7 @@ public class Video extends HttpServlet {
   private MonteRecorder videoRecorder;
 
   @Override
-  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws  IOException {
     doPost(req, resp);
   }
 
@@ -52,8 +51,11 @@ public class Video extends HttpServlet {
           String fileName = getFileName(req);
           File video = videoRecorder.stopAndSave(fileName);
           String filePath = doVideoProcessing(isSuccess(req), video);
-          updateResponse(resp, HttpStatus.SC_OK, filePath);
+          updateResponse(resp, HttpStatus.SC_OK, "recording stopped " + filePath);
           break;
+          default:
+            updateResponse(resp, HttpStatus.SC_NOT_FOUND,
+                "Wrong Action! Method doesn't support");
       }
     } catch (Exception ex) {
       updateResponse(resp, HttpStatus.SC_INTERNAL_SERVER_ERROR,

--- a/testng/src/main/java/com/automation/remarks/testng/GridInfoExtractor.java
+++ b/testng/src/main/java/com/automation/remarks/testng/GridInfoExtractor.java
@@ -2,7 +2,8 @@ package com.automation.remarks.testng;
 
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicHttpEntityEnclosingRequest;
 import org.apache.http.util.EntityUtils;
 import org.json.JSONObject;
@@ -19,7 +20,7 @@ public class GridInfoExtractor {
         final String hubIp = hubUrl.getHost();
         final int hubPort = hubUrl.getPort();
         HttpHost host = new HttpHost(hubIp, hubPort);
-        DefaultHttpClient client = new DefaultHttpClient();
+        HttpClient client = HttpClientBuilder.create().build();
         URL testSessionApi = new URL("http://" + hubIp + ":" + hubPort + "/grid/api/testsession?session=" + sessionId);
         BasicHttpEntityEnclosingRequest r = new
                 BasicHttpEntityEnclosingRequest("POST", testSessionApi.toExternalForm());

--- a/testng/src/main/java/com/automation/remarks/testng/IVideoRecordClient.java
+++ b/testng/src/main/java/com/automation/remarks/testng/IVideoRecordClient.java
@@ -1,0 +1,11 @@
+package com.automation.remarks.testng;
+
+/**
+ * Created by moonkin on 19.01.19
+ */
+interface IVideoRecordClient {
+  void start();
+
+  String stopAndSave(String fileName, boolean isTestSuccessful);
+
+}

--- a/testng/src/main/java/com/automation/remarks/testng/IVideoRecordClient.java
+++ b/testng/src/main/java/com/automation/remarks/testng/IVideoRecordClient.java
@@ -1,11 +1,7 @@
 package com.automation.remarks.testng;
 
-/**
- * Created by moonkin on 19.01.19
- */
 interface IVideoRecordClient {
   void start();
 
   String stopAndSave(String fileName, boolean isTestSuccessful);
-
 }

--- a/testng/src/main/java/com/automation/remarks/testng/LocalVideoRecordClient.java
+++ b/testng/src/main/java/com/automation/remarks/testng/LocalVideoRecordClient.java
@@ -1,0 +1,27 @@
+package com.automation.remarks.testng;
+
+import com.automation.remarks.video.RecorderFactory;
+import com.automation.remarks.video.recorder.IVideoRecorder;
+import com.automation.remarks.video.recorder.VideoRecorder;
+
+import static com.automation.remarks.video.RecordingUtils.doVideoProcessing;
+
+/**
+ * Created by moonkin on 19.01.19
+ */
+public class LocalVideoRecordClient implements IVideoRecordClient {
+
+  private IVideoRecorder recorder;
+
+  public void start() {
+    recorder = RecorderFactory.getRecorder(VideoRecorder.conf().recorderType());
+    recorder.start();
+  }
+
+  public String stopAndSave(String filename, boolean isTestSuccessful) {
+    if (recorder != null) {
+      return doVideoProcessing(isTestSuccessful, recorder.stopAndSave(filename));
+    }
+    return null;
+  }
+}

--- a/testng/src/main/java/com/automation/remarks/testng/LocalVideoRecordClient.java
+++ b/testng/src/main/java/com/automation/remarks/testng/LocalVideoRecordClient.java
@@ -6,18 +6,17 @@ import com.automation.remarks.video.recorder.VideoRecorder;
 
 import static com.automation.remarks.video.RecordingUtils.doVideoProcessing;
 
-/**
- * Created by moonkin on 19.01.19
- */
 public class LocalVideoRecordClient implements IVideoRecordClient {
 
   private IVideoRecorder recorder;
 
+  @Override
   public void start() {
     recorder = RecorderFactory.getRecorder(VideoRecorder.conf().recorderType());
     recorder.start();
   }
 
+  @Override
   public String stopAndSave(String filename, boolean isTestSuccessful) {
     if (recorder != null) {
       return doVideoProcessing(isTestSuccessful, recorder.stopAndSave(filename));

--- a/testng/src/main/java/com/automation/remarks/testng/RemoteVideoClient.java
+++ b/testng/src/main/java/com/automation/remarks/testng/RemoteVideoClient.java
@@ -40,5 +40,4 @@ public class RemoteVideoClient {
     }
     return videoFolder != null ? videoFolder.toString().replace("file:", "") : null;
   }
-
 }

--- a/testng/src/main/java/com/automation/remarks/testng/RemoteVideoClient.java
+++ b/testng/src/main/java/com/automation/remarks/testng/RemoteVideoClient.java
@@ -13,32 +13,32 @@ import static com.automation.remarks.testng.utils.RestUtils.sendRecordingRequest
  */
 public class RemoteVideoClient {
 
-    private String servletUrl;
+  private String servletUrl;
 
-    public RemoteVideoClient(String nodeUrl) {
-        String servletPath = "/extra/Video";
-        this.servletUrl = nodeUrl + servletPath;
-    }
+  public RemoteVideoClient(String nodeUrl) {
+    String servletPath = "/extra/Video";
+    this.servletUrl = nodeUrl + servletPath;
+  }
 
-    public void videoStart() {
-        String folder_url = encodeFilePath(new File(VideoRecorder.conf().folder()));
-        String url = servletUrl + "/start?&folder=" + folder_url;
-        sendRecordingRequest(url);
-    }
+  public void videoStart() {
+    String folderUrl = encodeFilePath(new File(VideoRecorder.conf().folder()));
+    String url = servletUrl + "/start?&folder=" + folderUrl;
+    sendRecordingRequest(url);
+  }
 
-    public void videoStop(String testName, boolean isSuccess) {
-        String url = servletUrl + "/stop?result=" + isSuccess + "&name=" + testName;
-        sendRecordingRequest(url);
-    }
+  public void videoStop(String testName, boolean isSuccess) {
+    String url = servletUrl + "/stop?result=" + isSuccess + "&name=" + testName;
+    sendRecordingRequest(url);
+  }
 
-    private String encodeFilePath(File file) {
-        URL videoFolder = null;
-        try {
-            videoFolder = file.toURI().toURL();
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        }
-        return videoFolder.toString().replace("file:", "");
+  private String encodeFilePath(File file) {
+    URL videoFolder = null;
+    try {
+      videoFolder = file.toURI().toURL();
+    } catch (MalformedURLException e) {
+      e.printStackTrace();
     }
+    return videoFolder != null ? videoFolder.toString().replace("file:", "") : null;
+  }
 
 }

--- a/testng/src/main/java/com/automation/remarks/testng/RemoteVideoRecordClient.java
+++ b/testng/src/main/java/com/automation/remarks/testng/RemoteVideoRecordClient.java
@@ -1,0 +1,44 @@
+package com.automation.remarks.testng;
+
+import com.automation.remarks.video.recorder.VideoRecorder;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static com.automation.remarks.testng.utils.RestUtils.sendRecordingRequest;
+
+/**
+ * Created by moonkin on 19.01.19.
+ */
+public class RemoteVideoRecordClient implements IVideoRecordClient {
+
+  private String servletUrl;
+
+  public RemoteVideoRecordClient(String nodeUrl) {
+    String servletPath = "/extra/Video";
+    this.servletUrl = nodeUrl + servletPath;
+  }
+
+  public void start() {
+    String folder_url = encodeFilePath(new File(VideoRecorder.conf().folder()));
+    String url = servletUrl + "/start?&folder=" + folder_url;
+    sendRecordingRequest(url);
+  }
+
+  public String stopAndSave(String testName, boolean isSuccess) {
+    String url = servletUrl + "/stop?result=" + isSuccess + "&name=" + testName;
+    return sendRecordingRequest(url);
+  }
+
+  private String encodeFilePath(File file) {
+    URL videoFolder = null;
+    try {
+      videoFolder = file.toURI().toURL();
+    } catch (MalformedURLException e) {
+      e.printStackTrace();
+    }
+    return videoFolder.toString().replace("file:", "");
+  }
+
+}

--- a/testng/src/main/java/com/automation/remarks/testng/RemoteVideoRecordClient.java
+++ b/testng/src/main/java/com/automation/remarks/testng/RemoteVideoRecordClient.java
@@ -8,27 +8,30 @@ import java.net.URL;
 
 import static com.automation.remarks.testng.utils.RestUtils.sendRecordingRequest;
 
-/**
- * Created by moonkin on 19.01.19.
- */
 public class RemoteVideoRecordClient implements IVideoRecordClient {
 
   private String servletUrl;
 
   public RemoteVideoRecordClient(String nodeUrl) {
     String servletPath = "/extra/Video";
-    this.servletUrl = nodeUrl + servletPath;
+    servletUrl = nodeUrl + servletPath;
   }
 
+  @Override
   public void start() {
-    String folder_url = encodeFilePath(new File(VideoRecorder.conf().folder()));
-    String url = servletUrl + "/start?&folder=" + folder_url;
+    String folderUrl = encodeFilePath(new File(VideoRecorder.conf().folder()));
+    String url = servletUrl + "/start?&folder=" + folderUrl;
     sendRecordingRequest(url);
   }
 
+  @Override
   public String stopAndSave(String testName, boolean isSuccess) {
     String url = servletUrl + "/stop?result=" + isSuccess + "&name=" + testName;
-    return sendRecordingRequest(url);
+    return getFilePathFromResponse(url);
+  }
+
+  private String getFilePathFromResponse(String url) {
+    return sendRecordingRequest(url).replace("recording stopped ", "");
   }
 
   private String encodeFilePath(File file) {
@@ -38,7 +41,7 @@ public class RemoteVideoRecordClient implements IVideoRecordClient {
     } catch (MalformedURLException e) {
       e.printStackTrace();
     }
-    return videoFolder.toString().replace("file:", "");
+    return videoFolder != null ? videoFolder.toString().replace("file:", "") : null;
   }
 
 }

--- a/testng/src/main/java/com/automation/remarks/testng/UniversalVideoListener.java
+++ b/testng/src/main/java/com/automation/remarks/testng/UniversalVideoListener.java
@@ -18,11 +18,6 @@ public class UniversalVideoListener extends TestNgListener {
   private IVideoRecordClient videoRecordClient;
 
   @Override
-  public void onStart(ITestContext context) {
-
-  }
-
-  @Override
   public void onTestStart(ITestResult result) {
     if (videoDisabled(result) || !shouldIntercept(result)) {
       return;
@@ -52,21 +47,6 @@ public class UniversalVideoListener extends TestNgListener {
     }
     String fileName = getFileName(result);
     videoRecordClient.stopAndSave(fileName, false);
-  }
-
-  @Override
-  public void onTestSkipped(ITestResult result) {
-    onTestFailure(result);
-  }
-
-  @Override
-  public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
-    onTestFailure(result);
-  }
-
-  @Override
-  public void onFinish(ITestContext context) {
-
   }
 
   private boolean videoDisabled(ITestResult result) {

--- a/testng/src/main/java/com/automation/remarks/testng/UniversalVideoListener.java
+++ b/testng/src/main/java/com/automation/remarks/testng/UniversalVideoListener.java
@@ -1,0 +1,80 @@
+package com.automation.remarks.testng;
+
+import com.automation.remarks.video.recorder.VideoRecorder;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
+
+import java.util.List;
+
+import static com.automation.remarks.testng.utils.ListenerUtils.getFileName;
+import static com.automation.remarks.testng.utils.MethodUtils.getVideoAnnotation;
+import static com.automation.remarks.video.RecordingUtils.videoEnabled;
+
+/**
+ * Created by moonkin on 19.01.19
+ */
+public class UniversalVideoListener extends TestNgListener {
+
+  private IVideoRecordClient videoRecordClient;
+
+  @Override
+  public void onStart(ITestContext context) {
+
+  }
+
+  @Override
+  public void onTestStart(ITestResult result) {
+    if (videoDisabled(result) || !shouldIntercept(result)) {
+      return;
+    }
+    if (VideoRecorder.conf().isRemote()) {
+      String nodeUrl = VideoRecorder.conf().remoteUrl();
+      videoRecordClient = new RemoteVideoRecordClient(nodeUrl);
+    } else {
+      videoRecordClient = new LocalVideoRecordClient();
+    }
+    videoRecordClient.start();
+  }
+
+  @Override
+  public void onTestSuccess(ITestResult result) {
+    if (videoDisabled(result) || !shouldIntercept(result)) {
+      return;
+    }
+    String fileName = getFileName(result);
+    videoRecordClient.stopAndSave(fileName, true);
+  }
+
+  @Override
+  public void onTestFailure(ITestResult result) {
+    if (videoDisabled(result) || !shouldIntercept(result)) {
+      return;
+    }
+    String fileName = getFileName(result);
+    videoRecordClient.stopAndSave(fileName, false);
+  }
+
+  @Override
+  public void onTestSkipped(ITestResult result) {
+    onTestFailure(result);
+  }
+
+  @Override
+  public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
+    onTestFailure(result);
+  }
+
+  @Override
+  public void onFinish(ITestContext context) {
+
+  }
+
+  private boolean videoDisabled(ITestResult result) {
+    return !videoEnabled(getVideoAnnotation(result));
+  }
+
+  public boolean shouldIntercept(ITestResult result) {
+    List<String> listeners = result.getTestContext().getCurrentXmlTest().getSuite().getListeners();
+    return listeners.contains(this.getClass().getName()) || shouldIntercept(result.getTestClass().getRealClass(), this.getClass());
+  }
+}

--- a/testng/src/main/java/com/automation/remarks/testng/UniversalVideoListener.java
+++ b/testng/src/main/java/com/automation/remarks/testng/UniversalVideoListener.java
@@ -1,7 +1,6 @@
 package com.automation.remarks.testng;
 
 import com.automation.remarks.video.recorder.VideoRecorder;
-import org.testng.ITestContext;
 import org.testng.ITestResult;
 
 import java.util.List;
@@ -19,7 +18,7 @@ public class UniversalVideoListener extends TestNgListener {
 
   @Override
   public void onTestStart(ITestResult result) {
-    if (videoDisabled(result) || !shouldIntercept(result)) {
+    if (videoDisabled(result) || shouldNotIntercept(result)) {
       return;
     }
     if (VideoRecorder.conf().isRemote()) {
@@ -33,7 +32,7 @@ public class UniversalVideoListener extends TestNgListener {
 
   @Override
   public void onTestSuccess(ITestResult result) {
-    if (videoDisabled(result) || !shouldIntercept(result)) {
+    if (videoDisabled(result) || shouldNotIntercept(result)) {
       return;
     }
     String fileName = getFileName(result);
@@ -42,7 +41,7 @@ public class UniversalVideoListener extends TestNgListener {
 
   @Override
   public void onTestFailure(ITestResult result) {
-    if (videoDisabled(result) || !shouldIntercept(result)) {
+    if (videoDisabled(result) || shouldNotIntercept(result)) {
       return;
     }
     String fileName = getFileName(result);
@@ -53,8 +52,8 @@ public class UniversalVideoListener extends TestNgListener {
     return !videoEnabled(getVideoAnnotation(result));
   }
 
-  public boolean shouldIntercept(ITestResult result) {
+  public boolean shouldNotIntercept(ITestResult result) {
     List<String> listeners = result.getTestContext().getCurrentXmlTest().getSuite().getListeners();
-    return listeners.contains(this.getClass().getName()) || shouldIntercept(result.getTestClass().getRealClass(), this.getClass());
+    return !listeners.contains(this.getClass().getName()) && !shouldIntercept(result.getTestClass().getRealClass(), this.getClass());
   }
 }


### PR DESCRIPTION
Good day, I'd like to offer some modifications for your project.
I think that the current API is not comfortable enough so I decided to make it more universal. I added a common listener and unified video record clients. Also I added the ability to change the name of video in runtime. It was necessary during the using Cucumber because all scenarios are run from one method and have the similar names.